### PR TITLE
Update AsyncConverter.nuspec

### DIFF
--- a/AsyncConverter/AsyncConverter.nuspec
+++ b/AsyncConverter/AsyncConverter.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>AsyncConverter.AsyncConverter</id>
     <title>AsyncConverter</title>
-    <version>1.1.6.2</version>
+    <version>1.1.6.3</version>
     <authors>i.mamay</authors>
     <copyright>i.mamay</copyright>
     <owners>i.mamay</owners>
@@ -13,7 +13,7 @@
     <projectUrl>https://github.com/BigBabay/AsyncConverter</projectUrl>
     <tags>async</tags>
     <dependencies>
-      <dependency id="Wave" version="7.0" />
+      <dependency id="Wave" version="[7.0]" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
This changes the dependency on the `Wave` package to be exactly 7.0, and not any higher. Without this change, it is dependent on Wave >= 7.0, which means that when the package is uploaded to the plugin gallery, it is also visible to Wave 8.0. This means it's visible in the Extension Manager for 2017.1 EAP builds, but it's not compatible. To fix this:

* Change the dependency to Wave to be `"[7.0]"`
* Upload a new version with this fixed dependency and mark the previous version as "unlisted" in resharpen-plugins.jetbrains.com. Marking it unlisted will prevent the gallery from showing it to ReSharper 2017.1 EAP builds