### PR TITLE
Added MsTest's DataTestMethodAttribute to the attributes determing a …

### DIFF
--- a/AsyncConverter/AsyncHelpers/RenameCheckers/TestAsyncMethodRenameChecker.cs
+++ b/AsyncConverter/AsyncHelpers/RenameCheckers/TestAsyncMethodRenameChecker.cs
@@ -15,10 +15,11 @@ namespace AsyncConverter.AsyncHelpers.RenameCheckers
         private readonly HashSet<ClrTypeName> testAttributesClass = new HashSet<ClrTypeName>
                                                            {
                                                                new ClrTypeName("Microsoft.VisualStudio.TestTools.UnitTesting.TestMethodAttribute"),
+                                                               new ClrTypeName("Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute"),
                                                                new ClrTypeName("Xunit.FactAttribute"),
                                                                new ClrTypeName("Xunit.TheoryAttribute"),
                                                                new ClrTypeName("NUnit.Framework.TestAttribute"),
-                                                               new ClrTypeName("NUnit.Framework.TestCaseAttribute"),
+                                                               new ClrTypeName("NUnit.Framework.TestCaseAttribute")
                                                            };
 
         public bool SkipRename(IMethodDeclaration method)


### PR DESCRIPTION
…test method.

This should stop suggesting a async suffix for data test methods.