### PR TITLE
Updated to support 2020.1 version of Resharper and Rider

### DIFF
--- a/AsyncConverter.Tests/AsyncConverter.Rider.Tests.csproj
+++ b/AsyncConverter.Tests/AsyncConverter.Rider.Tests.csproj
@@ -30,9 +30,15 @@
     <ProjectReference Include="..\AsyncConverter\AsyncConverter.Rider.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2019.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
+    <PackageReference Include="JetBrains.Lifetimes" Version="2020.1.3" />
+    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="16.3.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Remove="Packages\**" />

--- a/AsyncConverter.Tests/AsyncConverter.Tests.csproj
+++ b/AsyncConverter.Tests/AsyncConverter.Tests.csproj
@@ -26,7 +26,10 @@
     <None Remove="Test\Data\**\*.cs.tmp" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2019.3.0" />
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="16.3.0" />
   </ItemGroup>

--- a/AsyncConverter/AsyncConverter.Rider.csproj
+++ b/AsyncConverter/AsyncConverter.Rider.csproj
@@ -32,8 +32,8 @@
     <None Remove="packages.AsyncConverter.Rider.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="2019.3.0" PrivateAssets="All" />
-    <PackageReference Include="Wave" Version="[193]" />
+    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.1.0" PrivateAssets="All" />
+    <PackageReference Include="Wave" Version="[201]" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="tmp\**" />

--- a/AsyncConverter/AsyncConverter.csproj
+++ b/AsyncConverter/AsyncConverter.csproj
@@ -28,7 +28,7 @@
     <None Remove="packages.AsyncConverter.Rider.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2019.3.0" PrivateAssets="All" />
-    <PackageReference Include="Wave" Version="[193]" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.1.0" PrivateAssets="All" />
+    <PackageReference Include="Wave" Version="[201]" />
   </ItemGroup>
 </Project>

--- a/AsyncConverter/AsyncHelpers/ClassSearchers/EntityFrameworkCustomSearcher.cs
+++ b/AsyncConverter/AsyncHelpers/ClassSearchers/EntityFrameworkCustomSearcher.cs
@@ -1,4 +1,5 @@
 using AsyncConverter.Helpers;
+using JetBrains.Metadata.Reader.API;
 using JetBrains.Metadata.Reader.Impl;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Psi;


### PR DESCRIPTION
Updated to support the 2020.1 version of Resharper and Rider. I need to add a couple of extra nuget references to JetBrains.Annotations, JetBrains.Lifetimes & Nuint as well as updating the Resharper & Rider references.