### PR TITLE
Support for ReSharper and Rider version 2020.3

### DIFF
--- a/AsyncConverter.Tests/AsyncConverter.Rider.Tests.csproj
+++ b/AsyncConverter.Tests/AsyncConverter.Rider.Tests.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="..\AsyncConverter\AsyncConverter.Rider.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.2.0" />
+    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.0" />
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="16.7.0" />
   </ItemGroup>

--- a/AsyncConverter.Tests/AsyncConverter.Tests.csproj
+++ b/AsyncConverter.Tests/AsyncConverter.Tests.csproj
@@ -26,7 +26,7 @@
     <None Remove="Test\Data\**\*.cs.tmp" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.2.0" />
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.3.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.0" />
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="16.7.0" />
   </ItemGroup>

--- a/AsyncConverter/AsyncConverter.Rider.csproj
+++ b/AsyncConverter/AsyncConverter.Rider.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net461</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageId>AsyncConverter.Rider</PackageId>
-    <Version>1.2.8.29</Version>
+    <Version>1.2.8.30</Version>
     <Authors>i.mamay</Authors>
     <Company />
     <Product />
@@ -32,8 +32,8 @@
     <None Remove="packages.AsyncConverter.Rider.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.2.0" PrivateAssets="All" />
-    <PackageReference Include="Wave" Version="[202]" />
+    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.3.0" PrivateAssets="All" />
+    <PackageReference Include="Wave" Version="[203]" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="tmp\**" />

--- a/AsyncConverter/AsyncConverter.csproj
+++ b/AsyncConverter/AsyncConverter.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net461</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageId>AsyncConverter.AsyncConverter</PackageId>
-    <Version>1.1.8.29</Version>
+    <Version>1.1.8.30</Version>
     <Authors>i.mamay</Authors>
     <Company />
     <Product />
@@ -28,7 +28,7 @@
     <None Remove="packages.AsyncConverter.Rider.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.2.0" PrivateAssets="All" />
-    <PackageReference Include="Wave" Version="[202]" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.3.0" PrivateAssets="All" />
+    <PackageReference Include="Wave" Version="[203]" />
   </ItemGroup>
 </Project>

--- a/Rider/AsyncConverter.Rider/META-INF/plugin.xml
+++ b/Rider/AsyncConverter.Rider/META-INF/plugin.xml
@@ -2,9 +2,9 @@
   <id>AsyncConverter.AsyncConverter</id>
   <name>AsyncConverter</name>
   <description>Plugin for converting code to async.</description>
-  <version>1.2.8.29</version>
+  <version>1.2.8.30</version>
   <vendor url="https://github.com/BigBabay/AsyncConverter">i.mamay</vendor>
-  <idea-version since-build="202" until-build="202.*"/>
+  <idea-version since-build="203" until-build="203.*"/>
   <extensions defaultExtensionNs="com.intellij" />
   <depends>com.intellij.modules.rider</depends>
 </idea-plugin>


### PR DESCRIPTION
Resolves #72
- Version bump to 1.2.8.30
- Update Wave version to 203
- Update JetBrains.ReSharper.SDK version to 2020.3.0
- Update JetBrains.ReSharper.SDK.Tests version to 2020.3.0
- Update JetBrains.Rider.SDK version to 2020.3.0
- Update JetBrains.Rider.SDK.Tests version to 2020.3.0