### PR TITLE
Update JetBrains SDK to 2021.1

### DIFF
--- a/AsyncConverter.Tests/AsyncConverter.Rider.Tests.csproj
+++ b/AsyncConverter.Tests/AsyncConverter.Rider.Tests.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="..\AsyncConverter\AsyncConverter.Rider.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2020.3.0" />
+    <PackageReference Include="JetBrains.Rider.SDK.Tests" Version="2021.1.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.0" />
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="16.7.0" />
   </ItemGroup>

--- a/AsyncConverter.Tests/AsyncConverter.Tests.csproj
+++ b/AsyncConverter.Tests/AsyncConverter.Tests.csproj
@@ -26,7 +26,7 @@
     <None Remove="Test\Data\**\*.cs.tmp" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2020.3.0" />
+    <PackageReference Include="JetBrains.ReSharper.SDK.Tests" Version="2021.1.0" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.0" />
     <PackageReference Include="Microsoft.TestPlatform.TranslationLayer" Version="16.7.0" />
   </ItemGroup>

--- a/AsyncConverter.Tests/Test/Data/nuget.config
+++ b/AsyncConverter.Tests/Test/Data/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <config>
     <!-- See https://docs.nuget.org/consume/nuget-config-file for config options -->
-    <add key="repositoryPath" value="./packages.tests" />
+    <add key="repositoryPath" value="./packages" />
   </config>
   <packageSources>
     <!-- Clear any existing package sources -->

--- a/AsyncConverter.Tests/Test/Data/nuget.config
+++ b/AsyncConverter.Tests/Test/Data/nuget.config
@@ -2,6 +2,7 @@
 <configuration>
   <config>
     <!-- See https://docs.nuget.org/consume/nuget-config-file for config options -->
+    <add key="repositoryPath" value="./packages.tests" />
   </config>
   <packageSources>
     <!-- Clear any existing package sources -->

--- a/AsyncConverter/AsyncConverter.Rider.csproj
+++ b/AsyncConverter/AsyncConverter.Rider.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net461</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageId>AsyncConverter.Rider</PackageId>
-    <Version>1.2.8.30</Version>
+    <Version>1.2.8.31</Version>
     <Authors>i.mamay</Authors>
     <Company />
     <Product />
@@ -32,8 +32,8 @@
     <None Remove="packages.AsyncConverter.Rider.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Rider.SDK" Version="2020.3.0" PrivateAssets="All" />
-    <PackageReference Include="Wave" Version="[203]" />
+    <PackageReference Include="JetBrains.Rider.SDK" Version="2021.1.0" PrivateAssets="All" />
+    <PackageReference Include="Wave" Version="[211]" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="tmp\**" />

--- a/AsyncConverter/AsyncConverter.csproj
+++ b/AsyncConverter/AsyncConverter.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net461</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageId>AsyncConverter.AsyncConverter</PackageId>
-    <Version>1.1.8.30</Version>
+    <Version>1.1.8.31</Version>
     <Authors>i.mamay</Authors>
     <Company />
     <Product />
@@ -28,7 +28,7 @@
     <None Remove="packages.AsyncConverter.Rider.config" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2020.3.0" PrivateAssets="All" />
-    <PackageReference Include="Wave" Version="[203]" />
+    <PackageReference Include="JetBrains.ReSharper.SDK" Version="2021.1.0" PrivateAssets="All" />
+    <PackageReference Include="Wave" Version="[211]" />
   </ItemGroup>
 </Project>

--- a/AsyncConverter/ContextActions/MethodToAsyncConverter.cs
+++ b/AsyncConverter/ContextActions/MethodToAsyncConverter.cs
@@ -4,7 +4,7 @@ using JetBrains.Annotations;
 using JetBrains.Application.Progress;
 using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Feature.Services.ContextActions;
-using JetBrains.ReSharper.Feature.Services.CSharp.Analyses.Bulbs;
+using JetBrains.ReSharper.Feature.Services.CSharp.ContextActions;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
 using JetBrains.TextControl;

--- a/Rider/AsyncConverter.Rider/META-INF/plugin.xml
+++ b/Rider/AsyncConverter.Rider/META-INF/plugin.xml
@@ -2,9 +2,9 @@
   <id>AsyncConverter.AsyncConverter</id>
   <name>AsyncConverter</name>
   <description>Plugin for converting code to async.</description>
-  <version>1.2.8.30</version>
+  <version>1.2.8.31</version>
   <vendor url="https://github.com/BigBabay/AsyncConverter">i.mamay</vendor>
-  <idea-version since-build="203" until-build="203.*"/>
+  <idea-version since-build="211" until-build="211.*"/>
   <extensions defaultExtensionNs="com.intellij" />
   <depends>com.intellij.modules.rider</depends>
 </idea-plugin>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.1.8.{build}
 configuration: Release
-image: Visual Studio 2017
+image: Visual Studio 2019
 nuget:
   project_feed: true
 build_script:


### PR DESCRIPTION
- Version bump to 1.2.8.31
- Update Wave version to 211
- Update JetBrains.ReSharper.SDK version to 2021.1.0
- Update JetBrains.ReSharper.SDK.Tests version to 2021.1.0
- Update JetBrains.Rider.SDK version to 2021.1.0
- Update JetBrains.Rider.SDK.Tests version to 2021.1.0

Resolves #76